### PR TITLE
fix: set share kit sdk version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
       language: node_js
       node_js: "8"
       jdk: oraclejdk8
+      before_script: pod repo update
       script: cd src && npm run build.iosOnly && cd ../demo && npm i && tns build ios --env.uglify && cd ../demo-angular && npm i && tns build ios --env.uglify --env.aot
     - language: android
       os: linux
@@ -52,6 +53,7 @@ matrix:
       language: node_js
       node_js: "8"
       jdk: oraclejdk8
+      before_script: pod repo update
       script:
         - cd demo && npm run ci.ios.build && cd ../demo-angular && npm run ci.ios.build
         - cd $IOS_PACKAGE_FOLDER && zip -r $IOS_PACKAGE demo.app

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,3 +1,3 @@
 pod 'FBSDKCoreKit', '~> 4.7'
 pod 'FBSDKLoginKit', '~> 4.7'
-pod 'FBSDKShareKit', '~> 4.7'
+pod 'FBSDKShareKit', '4.38.1'

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,3 +1,3 @@
 pod 'FBSDKCoreKit', '~> 4.7'
 pod 'FBSDKLoginKit', '~> 4.7'
-pod 'FBSDKShareKit', '4.38.1'
+pod 'FBSDKShareKit', '~> 4.39.1'

--- a/src/platforms/ios/typings/objc!FBSDKShareKit.d.ts
+++ b/src/platforms/ios/typings/objc!FBSDKShareKit.d.ts
@@ -217,13 +217,13 @@ declare class FBSDKAppInviteDialog extends NSObject {
 
 	static showWithContentDelegate(content: FBSDKAppInviteContent, delegate: FBSDKAppInviteDialogDelegate): FBSDKAppInviteDialog;
 
+	readonly canShow: boolean;
+
 	content: FBSDKAppInviteContent;
 
 	delegate: FBSDKAppInviteDialogDelegate;
 
 	fromViewController: UIViewController;
-
-	canShow(): boolean;
 
 	show(): boolean;
 
@@ -455,13 +455,13 @@ declare class FBSDKGameRequestDialog extends NSObject {
 
 	static showWithContentDelegate(content: FBSDKGameRequestContent, delegate: FBSDKGameRequestDialogDelegate): FBSDKGameRequestDialog;
 
+	readonly canShow: boolean;
+
 	content: FBSDKGameRequestContent;
 
 	delegate: FBSDKGameRequestDialogDelegate;
 
 	frictionlessRequestsEnabled: boolean;
-
-	canShow(): boolean;
 
 	show(): boolean;
 
@@ -734,6 +734,8 @@ declare class FBSDKMessageDialog extends NSObject implements FBSDKSharingDialog 
 
 	static showWithContentDelegate(content: FBSDKSharingContent, delegate: FBSDKSharingDelegate): FBSDKMessageDialog;
 
+	readonly canShow: boolean; // inherited from FBSDKSharingDialog
+
 	readonly debugDescription: string; // inherited from NSObjectProtocol
 
 	delegate: FBSDKSharingDelegate; // inherited from FBSDKSharing
@@ -751,8 +753,6 @@ declare class FBSDKMessageDialog extends NSObject implements FBSDKSharingDialog 
 	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
 	readonly  // inherited from NSObjectProtocol
-
-	canShow(): boolean;
 
 	class(): typeof NSObject;
 
@@ -848,6 +848,8 @@ declare class FBSDKShareAPI extends NSObject implements FBSDKSharing {
 
 	accessToken: FBSDKAccessToken;
 
+	readonly canShare: boolean;
+
 	graphNode: string;
 
 	message: string;
@@ -869,8 +871,6 @@ declare class FBSDKShareAPI extends NSObject implements FBSDKSharing {
 	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
 	readonly  // inherited from NSObjectProtocol
-
-	canShare(): boolean;
 
 	class(): typeof NSObject;
 
@@ -1068,6 +1068,8 @@ declare class FBSDKShareDialog extends NSObject implements FBSDKSharingDialog {
 
 	mode: FBSDKShareDialogMode;
 
+	readonly canShow: boolean; // inherited from FBSDKSharingDialog
+
 	readonly debugDescription: string; // inherited from NSObjectProtocol
 
 	delegate: FBSDKSharingDelegate; // inherited from FBSDKSharing
@@ -1085,8 +1087,6 @@ declare class FBSDKShareDialog extends NSObject implements FBSDKSharingDialog {
 	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
 	readonly  // inherited from NSObjectProtocol
-
-	canShow(): boolean;
 
 	class(): typeof NSObject;
 
@@ -2422,7 +2422,7 @@ declare var FBSDKSharingDelegate: {
 
 interface FBSDKSharingDialog extends FBSDKSharing {
 
-	canShow(): boolean;
+	canShow: boolean;
 
 	show(): boolean;
 }

--- a/src/share-manager.ios.ts
+++ b/src/share-manager.ios.ts
@@ -150,7 +150,7 @@ export function canShareDialogShow(content: any): boolean {
     if (content) {
         const dialog = getShareDialog();
         getShareDialog().shareContent = content;
-        return dialog.canShow();
+        return dialog.canShow;
     }
     return false;
 }
@@ -169,7 +169,7 @@ export function canMessageDialogShow(content: any): boolean {
     if (content) {
         const dialog = getMessageDialog();
         getMessageDialog().shareContent = content;
-        return dialog.canShow();
+        return dialog.canShow;
     }
     return false;
 }


### PR DESCRIPTION
in 4.39 all canShow() methods are updated to properties