### PR TITLE
updated podfile to target v8 of the sdk

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,3 +1,3 @@
-pod 'FBSDKCoreKit', '~> 5.0'
-pod 'FBSDKLoginKit', '~> 5.0'
-pod 'FBSDKShareKit', '~> 5.0'
+pod 'FBSDKCoreKit', '~> 8.0'
+pod 'FBSDKLoginKit', '~> 8.0'
+pod 'FBSDKShareKit', '~> 8.0'


### PR DESCRIPTION
Since iOS 14, apps are required to have Facebook SDK v8 (or later) for advertising campaigns to work. This PR updates the versions inside the Podfile. The app seems to build correctly after the change and login with Facebook seems to keep working too.